### PR TITLE
Add talk idea form

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -26,6 +26,14 @@ app.get('/en/sponsoring', function(req, res) {
     res.render('en/sponsoring');
 });
 
+app.get('/talk-idea', function(req, res) {
+    res.render('talk-idea');
+});
+
+app.get('/en/talk-idea', function(req, res) {
+    res.render('en/talk-idea');
+});
+
 app.post('/', function(req, res) {
     console.log('post new talk', req.body);
 
@@ -70,6 +78,28 @@ app.post('/sponsoring', function(req, res) {
         });
 });
 
+app.post('/talk-idea', function(req, res) {
+    console.log('post new talk idea', req.body);
+
+    if (!req.body.title || !req.body.abstract) {
+        return res.sendStatus(400);
+    }
+
+    createTalkIdeaCard(
+        process.env.TRELLO_HOST,
+        process.env.TRELLO_TOKEN,
+        process.env.TRELLO_KEY,
+        process.env.TRELLO_ID_LIST_TALK_IDEA,
+        req.body,
+        function(err) {
+            if (err) {
+                return res.status(500).send(err.toString());
+            }
+
+            res.sendStatus(201);
+        });
+});
+
 exports.app = app;
 
 function createCard(type, host, token, key, data, callback) {
@@ -98,8 +128,8 @@ function createTalkCard(host, token, key, idList, form, callback) {
     var data = {
         idList: idList,
         name: form.title,
-        desc: form.abstract + "\n\n" +
-            "**" + form.author + "**",
+        desc: form.abstract + '\n\n' +
+            '**' + form.author + '**',
         labels: form.type == 'short' ? 'yellow' : 'blue'
     };
 
@@ -114,12 +144,22 @@ function createSponsoringCard(host, token, key, idList, form, callback) {
     ) : '';
     var data = {
         idList: idList,
-        name: form.entity + " sponsoring",
-        desc: form.period + "\n\n" +
-            formType.join(" + ") + audienceString + "\n\n" +
-            "**" + form.contact + "**",
+        name: form.entity + ' sponsoring',
+        desc: form.period + '\n\n' +
+            formType.join(' + ') + audienceString + '\n\n' +
+            '**' + form.contact + '**',
         labels: 'red'
     };
 
     createCard('sponsoring', host, token, key, data, callback);
+}
+
+function createTalkIdeaCard(host, token, key, idList, form, callback) {
+    var data = {
+        idList: idList,
+        name: form.title,
+        desc: form.abstract + ((form.author && form.author !== '') ? '\n\n**' + form.author + '**' : '')
+    };
+
+    createCard('talk', host, token, key, data, callback);
 }

--- a/views/en/talk-idea.jade
+++ b/views/en/talk-idea.jade
@@ -1,0 +1,23 @@
+extends layout
+
+block prepend head
+   title Talk idea for Paris.js
+
+block body
+  .container
+    h1 Talk idea for Paris.js
+    p Propose a talk idea. Someone from the community will do a talk.
+    form(method='post', action='/talk-idea')
+      label(for="title") Title
+      input#title.input-xxlarge(type="text", name="title")
+
+      label(for="abstract") Summary
+      span.help-block A summary of your idea.
+      textarea#abstract.input-xxlarge(name="abstract", rows="7")
+
+      label(for="author") Your nam + email (optional)
+      span.help-block If you wish to be notified when supported by a speaker.
+      input#author.input-xxlarge(type="text", name="author", placeholder='François francois@example.org')
+
+      br
+      input.btn.btn-primary(type="submit", value="Send")

--- a/views/talk-idea.jade
+++ b/views/talk-idea.jade
@@ -1,0 +1,23 @@
+extends layout
+
+block prepend head
+   title Idée de sujet pour Paris.js
+
+block body
+  .container
+    h1 Idée de sujet pour Paris.js
+    p Proposez une idée de sujet. Quelqu'un de la communauté en fera un talk.
+    form(method='post', action='/talk-idea')
+      label(for="title") Titre
+      input#title.input-xxlarge(type="text", name="title")
+
+      label(for="abstract") Résumé
+      span.help-block Un résumé de votre idée.
+      textarea#abstract.input-xxlarge(name="abstract", rows="7")
+
+      label(for="author") Votre nom + email (optionnel)
+      span.help-block Si vous souhaitez être prevenu lors de la prise en charge par un speaker
+      input#author.input-xxlarge(type="text", name="author", placeholder='François francois@example.org')
+
+      br
+      input.btn.btn-primary(type="submit", value="Envoyer")


### PR DESCRIPTION
Add new page: `/talk-idea`
There are a new form for propose idea subject but without want to be the speaker.

:warning: Should set `TRELLO_ID_LIST_TALK_IDEA` env to this list 
![image](https://cloud.githubusercontent.com/assets/1214544/16302555/16f65dfa-394c-11e6-8d35-873773a9b775.png)
